### PR TITLE
Polygon and MultiPolygon

### DIFF
--- a/example-app/src/main/java/com/example/getmap/DownloadListAdapter.kt
+++ b/example-app/src/main/java/com/example/getmap/DownloadListAdapter.kt
@@ -458,14 +458,29 @@ class DownloadListAdapter(
         notifValidation?.show()
     }
 
-    private fun formatDate(inputDate: String): String {
-        val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
-        inputFormat.timeZone = TimeZone.getTimeZone("UTC")
-        val outputFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-        outputFormat.timeZone = TimeZone.getDefault()
-        val date: Date = inputFormat.parse(inputDate)
-        return outputFormat.format(date)
+    private fun formatDate(inputDate: String?): String {
+        if (inputDate.isNullOrBlank()) {
+            return ""
+        }
+
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault()).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+            val outputFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+                timeZone = TimeZone.getDefault()
+            }
+
+            val date: Date = inputFormat.parse(inputDate)
+                ?: return ""
+
+            outputFormat.format(date)
+        } catch (e: Exception) {
+            Log.e("DownloadListAdapter", "formatDate failed for \"$inputDate\"", e)
+            ""
+        }
     }
+
 
     companion object {
         const val RESUME_BUTTON_CLICK = 1

--- a/sdk/src/main/java/com/ngsoft/getapp/sdk/utils/FootprintUtils.kt
+++ b/sdk/src/main/java/com/ngsoft/getapp/sdk/utils/FootprintUtils.kt
@@ -1,17 +1,16 @@
 package com.ngsoft.getapp.sdk.utils
 
-import android.util.Log
 import org.json.JSONObject
 
 internal object FootprintUtils {
-
+    @Throws(Exception::class)
     fun toString(footprint: JSONObject): String {
-        return try {
-            val type = footprint.getString("type")
-            val coordinatesArray = footprint.getJSONArray("coordinates")
-            val coordinatesString = StringBuilder()
+        val type = footprint.getString("type")
+        val coordinatesArray = footprint.getJSONArray("coordinates")
+        val coordinatesString = StringBuilder()
 
-            if (type == "Polygon") {
+        when (type) {
+            "Polygon" -> {
                 val ringArray = coordinatesArray.getJSONArray(0)
                 for (i in 0 until ringArray.length()) {
                     val pointArray = ringArray.getJSONArray(i)
@@ -19,7 +18,8 @@ internal object FootprintUtils {
                     val latitude = pointArray.getDouble(1)
                     coordinatesString.append("$longitude,$latitude,")
                 }
-            } else if (type == "MultiPolygon") {
+            }
+            "MultiPolygon" -> {
                 for (i in 0 until coordinatesArray.length()) {
                     val polygonArray = coordinatesArray.getJSONArray(i)
                     val ringArray = polygonArray.getJSONArray(0)
@@ -30,24 +30,16 @@ internal object FootprintUtils {
                         coordinatesString.append("$longitude,$latitude,")
                     }
                 }
-            } else {
-                Log.e("FootprintUtils", "Unknown geometry type: $type")
-                return ""
             }
-
-            if (coordinatesString.isNotEmpty()) {
-                coordinatesString.deleteCharAt(coordinatesString.length - 1)
-            }
-
-            return coordinatesString.toString()
-
-        } catch (e: Exception) {
-            Log.e("FootprintUtils", "Error parsing footprint: ${e.message}", e)
-            ""
+            else -> throw Exception("Unsupported footprint geometry type: $type")
         }
+
+        if (coordinatesString.isNotEmpty()) {
+            coordinatesString.setLength(coordinatesString.length - 1)
+        }
+
+        return coordinatesString.toString()
     }
 
-
     fun toList(footprint: String): List<Double> = footprint.split(",").map { it.toDouble() }
-
 }

--- a/sdk/src/main/java/com/ngsoft/getapp/sdk/utils/FootprintUtils.kt
+++ b/sdk/src/main/java/com/ngsoft/getapp/sdk/utils/FootprintUtils.kt
@@ -1,31 +1,52 @@
 package com.ngsoft.getapp.sdk.utils
 
+import android.util.Log
 import org.json.JSONObject
 
 internal object FootprintUtils {
 
-    fun toString(footprint: JSONObject): String{
-        val coordinatesArray = footprint
-            .getJSONArray("coordinates")
-            .getJSONArray(0) // Assuming there's only one set of coordinates in the example
+    fun toString(footprint: JSONObject): String {
+        return try {
+            val type = footprint.getString("type")
+            val coordinatesArray = footprint.getJSONArray("coordinates")
+            val coordinatesString = StringBuilder()
 
-        val coordinatesString = StringBuilder()
-
-        for (i in 0 until coordinatesArray.length()) {
-            val innerArray = coordinatesArray.getJSONArray(i)
-            for (j in 0 until innerArray.length()) {
-                val pointArray = innerArray.getJSONArray(j)
-                val longitude = pointArray.getDouble(0)
-                val latitude = pointArray.getDouble(1)
-
-                coordinatesString.append("$longitude,$latitude,")
+            if (type == "Polygon") {
+                val ringArray = coordinatesArray.getJSONArray(0)
+                for (i in 0 until ringArray.length()) {
+                    val pointArray = ringArray.getJSONArray(i)
+                    val longitude = pointArray.getDouble(0)
+                    val latitude = pointArray.getDouble(1)
+                    coordinatesString.append("$longitude,$latitude,")
+                }
+            } else if (type == "MultiPolygon") {
+                for (i in 0 until coordinatesArray.length()) {
+                    val polygonArray = coordinatesArray.getJSONArray(i)
+                    val ringArray = polygonArray.getJSONArray(0)
+                    for (j in 0 until ringArray.length()) {
+                        val pointArray = ringArray.getJSONArray(j)
+                        val longitude = pointArray.getDouble(0)
+                        val latitude = pointArray.getDouble(1)
+                        coordinatesString.append("$longitude,$latitude,")
+                    }
+                }
+            } else {
+                Log.e("FootprintUtils", "Unknown geometry type: $type")
+                return ""
             }
-        }
 
-        // Remove the trailing comma
-        coordinatesString.deleteCharAt(coordinatesString.length - 1)
-        return coordinatesString.toString()
+            if (coordinatesString.isNotEmpty()) {
+                coordinatesString.deleteCharAt(coordinatesString.length - 1)
+            }
+
+            return coordinatesString.toString()
+
+        } catch (e: Exception) {
+            Log.e("FootprintUtils", "Error parsing footprint: ${e.message}", e)
+            ""
+        }
     }
+
 
     fun toList(footprint: String): List<Double> = footprint.split(",").map { it.toDouble() }
 


### PR DESCRIPTION
Refactor: Handle MultiPolygon footprints and improve date formatting
The `FootprintUtils.toString()` method now supports "MultiPolygon" geometry types in addition to "Polygon". Error handling has been added for unknown geometry types and parsing errors.

The `formatDate` method in `DownloadListAdapter` now handles null or blank input dates and includes error logging for parsing failures.