### PR TITLE
Add configuration options for map path and pattern

### DIFF
--- a/example-app/src/main/java/com/example/getmap/SettingsActivity.kt
+++ b/example-app/src/main/java/com/example/getmap/SettingsActivity.kt
@@ -285,7 +285,12 @@ class SettingsActivity : AppCompatActivity() {
             NebulaParam("Flash Storage Path", service.config.flashStoragePath),
             NebulaParam("Target Storage Policy", service.config.targetStoragePolicy.value, true),
             NebulaParam("flashInventoryMaxSizeMB",service.config.flashInventoryMaxSizeMB.toString()),
-            NebulaParam("sdInventoryMaxSizeMB", service.config.sdInventoryMaxSizeMB.toString())
+            NebulaParam("sdInventoryMaxSizeMB", service.config.sdInventoryMaxSizeMB.toString()),
+            //20
+            NebulaParam("Ortophoto Map Path", service.config.ortophotoMapPath.toString()),
+            NebulaParam("Control Map Path", service.config.controlMapPath.toString()),
+            NebulaParam("Ortophoto Map Pattern", service.config.ortophotoMapPattern.toString()),
+            NebulaParam("Control Map Pattern",service.config.controlMapPattern.toString()),
 
             )
         nebulaParamAdapter.updateAll(params)
@@ -473,6 +478,32 @@ private fun saveLocalToService(
         NotifyValidity(notifValidation, context)
         params[18].value = service.config.sdInventoryMaxSizeMB.toString()
     }
+    if (params[19].value != "") {
+        service.config.ortophotoMapPath = params[19].value
+    } else {
+        NotifyValidity(notifValidation, context)
+        params[19].value = service.config.ortophotoMapPath
+    }
+    if (params[20].value != "") {
+        service.config.controlMapPath = params[20].value
+    } else {
+        NotifyValidity(notifValidation, context)
+        params[20].value = service.config.controlMapPath
+    }
+    if (params[21].value != "") {
+        service.config.ortophotoMapPattern = params[21].value
+    } else {
+        NotifyValidity(notifValidation, context)
+        params[21].value = service.config.ortophotoMapPattern
+    }
+    if (params[22].value != "") {
+        service.config.controlMapPattern = params[22].value
+    } else {
+        NotifyValidity(notifValidation, context)
+        params[22].value = service.config.controlMapPattern
+    }
+
+
 
     if (params[10].value != "")
         service.config.matomoSiteId = params[10].value
@@ -527,6 +558,18 @@ private fun hasChanged(
     if (params[18].value != "")
         if (service.config.sdInventoryMaxSizeMB != params[18].value.toLong())
             toReturn["sdInventoryMaxSizeMB"] = params[18].value
+    if (params[19].value != "")
+        if (service.config.ortophotoMapPath != params[19].value)
+            toReturn["ortophotoMapPath"] = params[19].value
+    if (params[20].value != "")
+        if (service.config.controlMapPath != params[20].value)
+            toReturn["controlMapPath"] = params[20].value
+    if (params[21].value != "")
+        if (service.config.ortophotoMapPattern != params[21].value)
+            toReturn["ortophotoMapPattern"] = params[21].value
+    if (params[22].value != "")
+        if (service.config.controlMapPattern != params[22].value)
+            toReturn["controlMapPattern"] = params[22].value
 
     return toReturn
 }

--- a/sdk/src/main/java/com/ngsoft/getapp/sdk/GetMapService.kt
+++ b/sdk/src/main/java/com/ngsoft/getapp/sdk/GetMapService.kt
@@ -389,21 +389,21 @@ interface GetMapService {
         /**
          * Ortophoto map path on the device
          */
-        val ortophotoMapPath: String?
+        var ortophotoMapPath: String
 
         /**
          * Control map path on the device
          */
-        val controlMapPath: String?
+        var controlMapPath: String
 
         /**
          * Substring to match in ortophoto map filename
          */
-        val ortophotoMapPattern: String?;
+        var ortophotoMapPattern: String
 
         /**
          * Substring to match in control map filename
          */
-        val controlMapPattern: String?;
+        var controlMapPattern: String
     }
 }


### PR DESCRIPTION
This commit introduces the ability to configure paths and patterns for Ortophoto and Control maps within the example application's settings and the SDK.

Specifically, the following parameters can now be set:
- Ortophoto Map Path
- Control Map Path
- Ortophoto Map Pattern
- Control Map Pattern

These parameters are now accessible and modifiable through the `SettingsActivity` in the example app and are reflected in the `GetMapService.Config` interface within the SDK. The SDK's `ortophotoMapPath`, `controlMapPath`, `ortophotoMapPattern`, and `controlMapPattern` properties are now mutable (`var`) instead of read-only (`val`).