### PR TITLE
Improve config value check in settings

### DIFF
--- a/example-app/src/main/java/com/example/getmap/SettingsActivity.kt
+++ b/example-app/src/main/java/com/example/getmap/SettingsActivity.kt
@@ -549,7 +549,7 @@ private fun hasChanged(
     if (params[10].value != "" && params[10].value.toInt() > 0)
         if (service.config.matomoSiteId != params[10].value)
             toReturn["matomoSiteId"] = params[10].value
-    if (params[11].value != "")
+    if (params[11].value != "" && params[11].value.toInt() > 0)
         if (service.config.matomoDimensionId != params[11].value)
             toReturn["matomoDimensionId"] = params[11].value
     if (params[17].value != "")

--- a/example-app/src/main/java/com/example/getmap/models/ConfigParam.kt
+++ b/example-app/src/main/java/com/example/getmap/models/ConfigParam.kt
@@ -175,7 +175,7 @@ class ConfigParam {
         private fun defineType(holder: NebulaParamViewHolder) {
 
             val valItemView = holder.itemView.findViewById<TextInputEditText>(R.id.value_nebula)
-            val stringNames = arrayOf("Matomo dimension id", "Matomo site id")
+            val stringNames = arrayOf("Ortophoto Map Path", "Control Map Path", "Ortophoto Map Pattern", "Control Map Pattern")
             val passwordNames = arrayOf("URL", "Matomo Url")
             if (passwordNames.contains(Params[holder.adapterPosition].name))
                 valItemView.inputType = TYPE_TEXT_VARIATION_PASSWORD


### PR DESCRIPTION
The commit ensures that the `matomoDimensionId` in `SettingsActivity.kt` is only updated if the new value is a positive integer.

Additionally, it refines the input type determination in `ConfigParam.kt`. The `stringNames` array, previously used to identify parameters requiring specific input types, now includes "Ortophoto Map Path", "Control Map Path", "Ortophoto Map Pattern", and "Control Map Pattern". The entries "Matomo dimension id" and "Matomo site id" have been removed from this array, implying their input type is no longer specially handled by this logic.